### PR TITLE
xen-chosen.dtsi: decrease Dom0 RAM

### DIFF
--- a/meta-xt-rcar-driver-domain/recipes-kernel/linux/files/xen-chosen.dtsi
+++ b/meta-xt-rcar-driver-domain/recipes-kernel/linux/files/xen-chosen.dtsi
@@ -11,7 +11,7 @@
 
 / {
 	chosen {
-		bootargs = "dom0_mem=384M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 loglvl=info hmp-unsafe=true xsm=flask console_timestamps=boot";
+		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 loglvl=info hmp-unsafe=true xsm=flask console_timestamps=boot";
 		xen,dom0-bootargs = "console=hvc0 ignore_loglevel";
 		/delete-property/stdout-path;
 		modules {


### PR DESCRIPTION
This change is a consequence of decrease of the Dom0's initramfs size. Now we can reduce the amount of memory, assigned to Dom0.

Signed-off-by: Vladyslav Goncharuk vladyslav_goncharuk@epam.com