### PR TITLE
recipes-graphics: Update for Weston 10 found in Kirkstone

### DIFF
--- a/meta-xt-rcar-driver-domain/recipes-graphics/image/core-image-weston.bbappend
+++ b/meta-xt-rcar-driver-domain/recipes-graphics/image/core-image-weston.bbappend
@@ -1,0 +1,3 @@
+IMAGE_INSTALL:append = " \
+    preinit-weston \
+"

--- a/meta-xt-rcar-driver-domain/recipes-graphics/preinit_weston/files/preinit-weston.service
+++ b/meta-xt-rcar-driver-domain/recipes-graphics/preinit_weston/files/preinit-weston.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Preinit weston
+Before=weston.service displbe.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/preinit-weston.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=weston.service displbe.service

--- a/meta-xt-rcar-driver-domain/recipes-graphics/preinit_weston/files/preinit-weston.sh
+++ b/meta-xt-rcar-driver-domain/recipes-graphics/preinit_weston/files/preinit-weston.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+FILE=/etc/default/weston
+
+if ! [ -s ${FILE} ]; then # if the file is empty
+    # injecting the XDG_RUNTIME_DIR parameter
+    echo "XDG_RUNTIME_DIR=/run/user/$(id -u weston)" > ${FILE}
+fi

--- a/meta-xt-rcar-driver-domain/recipes-graphics/preinit_weston/preinit-weston.bb
+++ b/meta-xt-rcar-driver-domain/recipes-graphics/preinit_weston/preinit-weston.bb
@@ -1,0 +1,27 @@
+DESCRIPTION = "Weston preinit service"
+SECTION = "extras"
+LICENSE = "GPL-2.0-only"
+PR = "r0"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "preinit-weston.service"
+
+SRC_URI = " \
+    file://preinit-weston.service \
+    file://preinit-weston.sh \
+"
+
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+FILES:${PN} += " \
+    ${systemd_system_unitdir}/preinit-weston.service \
+    ${bindir}/preinit-weston.sh \
+"
+
+do_install:append() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/preinit-weston.service ${D}${systemd_system_unitdir}
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/preinit-weston.sh ${D}${bindir}
+}

--- a/meta-xt-rcar-driver-domain/recipes-graphics/wayland/weston-init.bbappend
+++ b/meta-xt-rcar-driver-domain/recipes-graphics/wayland/weston-init.bbappend
@@ -1,5 +1,0 @@
-do_install:append () {
-    sed -e '$a\\' \
-        -e '$a\echo "XDG_RUNTIME_DIR=/run/user/`id -u weston`" > /etc/default/weston' \
-        -i ${D}/${sysconfdir}/profile.d/weston.sh
-}


### PR DESCRIPTION
With the current configuration, the 'XDG_RUNTIME_DIR' environment variable is set only after login to the DomD. That is wrong and causing the DomU initialization failure. The 'XDG_RUNTIME_DIR' environment variable should be set right on the system's first boot before the dependent services ( weston, displbe ) are started inside the DomD.

This patch tries to address the wrong behavior by introducing the new 'preinit-weston' service.

Signed-off-by: Vladyslav Goncharuk vladyslav_goncharuk@epam.com